### PR TITLE
image-resizer文件夹处理优化及比例计算问题修复

### DIFF
--- a/harmony/image_resizer/src/main/ets/ImageResizerModule.ts
+++ b/harmony/image_resizer/src/main/ets/ImageResizerModule.ts
@@ -120,7 +120,7 @@ export class ImageResizerModule extends TurboModule implements TM.ImageResizer.S
         }
       } else {
         // "contain" (default) or "cover": keep its aspect ratio
-        let widthRatio = width / oldHeight;
+        let widthRatio = width / oldWidth;
         let heightRatio = height / oldHeight;
         let ratio;
         if (mode == "cover") {

--- a/harmony/image_resizer/src/main/ets/ImageResizerModule.ts
+++ b/harmony/image_resizer/src/main/ets/ImageResizerModule.ts
@@ -105,8 +105,8 @@ export class ImageResizerModule extends TurboModule implements TM.ImageResizer.S
     let imageIS = image.createImageSource(fd)
     let imagePM = await imageIS.createPixelMap({ editable: true });
     let imgInfo = await imagePM.getImageInfo();
-    let oldWidth = Math.round(px2vp(imgInfo.size.width));
-    let oldHeight = Math.round(px2vp(imgInfo.size.height));
+    let oldWidth = imgInfo.size.width;
+    let oldHeight = imgInfo.size.height;
 
     if (height > 0 && width > 0) {
       if (mode == "stretch") {


### PR DESCRIPTION
# Summary

fix:https://gitee.com/react-native-oh-library/usage-docs/issues/IB7G88
- 修复计算缩放比例 widthRatio的问题
- 处理压缩图片的宽和高将vp更改为px
- createResizedImage方法支持在应用沙盒目录cache文件夹下的子文件夹的处理

## Test Plan

![FF0F66BE-4B02-442B-BA28-ADC47E17B14B](https://github.com/user-attachments/assets/b9469686-53e2-490e-835f-eb0bcf7115c1)


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
