### PR TITLE
fix:修改缩放比例的取值方式，将取整改为对后五位之后四舍五入，避免实际缩放比例差异较大

### DIFF
--- a/harmony/image_resizer/src/main/ets/ImageResizerModule.ts
+++ b/harmony/image_resizer/src/main/ets/ImageResizerModule.ts
@@ -137,8 +137,8 @@ export class ImageResizerModule extends TurboModule implements TM.ImageResizer.S
       }
     }
 
-    let xScale = Math.round(this.finalWidth / oldWidth);
-    let yScale = Math.round(this.finalHeight / oldHeight);
+    let xScale = Number((this.finalWidth / oldWidth).toFixed(5));
+    let yScale = Number((this.finalHeight / oldHeight).toFixed(5));
 
     this.filePath = this.getCacheFilePath(format, uri);
     try {


### PR DESCRIPTION
# Summary
close:#8

- 修改缩放比例的取值方式，将直接对缩放比例进行取整更改为小数点后五位之后的四舍五入，避免因直接取整导致的实际缩放比例偏差较大，可能无变化，可能直接缩放成0

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
